### PR TITLE
Update faraday to 1.x

### DIFF
--- a/ably-rest.gemspec
+++ b/ably-rest.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '~> 0.12'
+  spec.add_runtime_dependency 'faraday', '~> 1.0'
   spec.add_runtime_dependency 'excon', '~> 0.55'
   spec.add_runtime_dependency 'typhoeus', '~> 1.4'
 

--- a/ably-rest.gemspec
+++ b/ably-rest.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'faraday', '~> 0.12'
   spec.add_runtime_dependency 'excon', '~> 0.55'
+  spec.add_runtime_dependency 'typhoeus', '~> 1.4'
 
   if RUBY_VERSION.match(/^1/)
     spec.add_runtime_dependency 'json', '< 2.0'
@@ -47,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.3'
   spec.add_development_dependency 'rspec', '~> 3.2.0'
   spec.add_development_dependency 'rspec-retry', '~> 0.4'
+  spec.add_development_dependency 'webrick'
   spec.add_development_dependency 'yard', '~> 0.9'
 
   if RUBY_VERSION.match(/^1/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,11 @@ require 'support/private_api_formatter'
 require 'support/protocol_helper'
 require 'support/random_helper'
 require 'support/test_logger_helper'
+require 'support/serialization_helper'
+
+RSpec.configure do |config|
+  config.include SerializationHelper
+end
 
 # Load in all shared behaviours
 Dir.glob(File.expand_path("../lib/submodules/ably-ruby/spec/shared/*.rb", File.dirname(__FILE__))).each do |file|


### PR DESCRIPTION
Updates the `faraday` dependency to 1.x and add some missing dev dependencies to the gemspec

Closes https://github.com/ably/ably-ruby-rest/issues/15