### PR TITLE
Bring dependencies in line with ably-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ To see what has changed in recent versions of Bundler, see the [CHANGELOG](CHANG
 
 Please note that the bulk of this repo is in fact a submodule of the [Ably Ruby REST & Realtime library](https://github.com/ably/ably-ruby). If you want to issue a PR, it is likely you should be looking in that repo to add features or make contributions.
 
+The dependencies in [`ably-rest.gemspec`](./ably-rest.gemspec) must be manually kept in sync with those in [`lib/submodules/ably-ruby/ably.gemspec`](./lib/submodules/ably-ruby/ably.gemspec).
+
 1. Fork it
 2. When pulling to local, make sure to also pull submodules (git submodule init && git submodule update)
 3. Create your feature branch (`git checkout -b my-new-feature`)
@@ -167,11 +169,12 @@ Please note that the bulk of this repo is in fact a submodule of the [Ably Ruby 
 4. Ensure submodules of this submodule are up to date using `git submodule update`
 5. Change dir back to root / `ably-ruby-rest`
 6. Stage changes made at submodule file `git add lib/submodules/ably-ruby`
-7. Commit the change `git commit -m "Version upgrade to v1.2.3"` and push the changes.
-8. Make a PR against `main`. Once the PR is approved, merge it into `main`
-9. Add a tag to the new `main` head commit and push to origin such as `git tag v1.2.3 && git push origin v1.2.3`
-10. Visit [https://github.com/ably/ably-ruby/tags](https://github.com/ably/ably-ruby/tags) and `Add release notes` for the release including links to the changelog entry. 
-11. Run `rake release` to publish the gem to [Rubygems](https://rubygems.org/gems/ably-rest)
+7. Bring dependency versions in [`ably-rest.gemspec`](./ably-rest.gemspec) in line with [`lib/submodules/ably-ruby/ably.gemspec`](./lib/submodules/ably-ruby/ably.gemspec)
+8. Commit the change `git commit -m "Version upgrade to v1.2.3"` and push the changes.
+9. Make a PR against `main`. Once the PR is approved, merge it into `main`
+10. Add a tag to the new `main` head commit and push to origin such as `git tag v1.2.3 && git push origin v1.2.3`
+11. Visit [https://github.com/ably/ably-ruby/tags](https://github.com/ably/ably-ruby/tags) and `Add release notes` for the release including links to the changelog entry. 
+12. Run `rake release` to publish the gem to [Rubygems](https://rubygems.org/gems/ably-rest)
 
 See the [Ably Ruby release process notes](https://github.com/ably/ably-ruby#release-process).
 

--- a/ably-rest.gemspec
+++ b/ably-rest.gemspec
@@ -32,25 +32,22 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'faraday', '~> 2.2'
-  spec.add_runtime_dependency 'excon', '~> 0.55'
   spec.add_runtime_dependency 'typhoeus', '~> 1.4'
   spec.add_runtime_dependency 'faraday-typhoeus', '~> 0.2.0'
 
   spec.add_runtime_dependency 'json'
-  spec.add_runtime_dependency 'msgpack', '>= 1.5.2', '< 2.0'
+  spec.add_runtime_dependency 'msgpack', '>= 1.3.0'
   spec.add_runtime_dependency 'addressable', '>= 2.0.0'
 
   spec.add_development_dependency 'bundler', '>= 1.3.0'
-  spec.add_development_dependency 'rake', '~> 13.0.6'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.3'
-  spec.add_development_dependency 'rspec', '~> 3.11'
-  spec.add_development_dependency 'rspec-retry', '~> 0.6.2'
+  spec.add_development_dependency 'rspec', '~> 3.11.0'
+  spec.add_development_dependency 'rspec-retry', '~> 0.6'
   spec.add_development_dependency 'yard', '~> 0.9'
-
-  spec.add_development_dependency 'webmock', '~> 3.14.0'
-  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'webmock', '~> 3.11'
   spec.add_development_dependency 'pry', '~> 0.14.1'
-  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'pry-byebug', '~> 3.8.0'
 
   if RUBY_VERSION.match(/^3\./)
     spec.add_development_dependency 'webrick', '~> 1.7.0'


### PR DESCRIPTION
They use the same code so it makes sense for them to use the same versions of things.